### PR TITLE
searchPage tab 삽입 (블로그, 유튜브 검색 통합 기능

### DIFF
--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -1,12 +1,21 @@
 <template>
-    <Form class="" v-slot="{ validate }">
-        <div class="p-1 border-gray-100 rounded-lg shadow-md flex justify-center my-2 ml-auto">
-            <Field name="search" rules="required" v-model="searchData"
-                class="border mr-2 rounded-lg p-2 border-none outline-none focus:ring-2 focus:ring-blue-500" type="text"
-                placeholder="검색어를 입력하세요" />
-            <button @click="(e) => handleSubmit(e, validate)" type="submit" class="mx-2 hover:font-bold">검색</button>
-        </div>
-    </Form>
+    <div class="flex items-center justify-center">
+        <q-btn v-if="searchType" flat round color="primary" icon="help" @click="tooltip = !tooltip" class="mr-2">
+            <q-tooltip v-model="tooltip" anchor="top middle" self="top middle" :offset="[0, 30]"
+                transition-show="jump-down" transition-hide="jump-up">
+                통합 검색 안내: 도서, 블로그, 유튜브를 한 번에 검색할 수 있습니다.
+            </q-tooltip>
+        </q-btn>
+        <Form class="" v-slot="{ validate }">
+            <div class="p-1 border-gray-100 rounded-lg shadow-md flex justify-center my-2 ml-auto">
+                <Field name="search" rules="required" v-model="searchData"
+                    class="border mr-2 rounded-lg p-2 border-none outline-none focus:ring-2 focus:ring-blue-500"
+                    type="text" placeholder="검색어를 입력하세요" />
+                <button @click="(e) => handleSubmit(e, validate)" type="submit" class="mx-2 hover:font-bold">검색</button>
+
+            </div>
+        </Form>
+    </div>
 </template>
 
 <script setup>
@@ -19,10 +28,17 @@ import { required } from '@vee-validate/rules';
 
 import { useQuasar } from 'quasar'
 
+const tooltip = ref(false)
 const $q = useQuasar();
 
 // ✅ 필수 유효성 검사 규칙 등록
 defineRule('required', required);
+defineProps({
+    searchType: {
+        type: Boolean,
+        default: true,
+    }
+})
 
 let searchData = ref('')
 const router = useRouter()

--- a/components/SearchTemplate.vue
+++ b/components/SearchTemplate.vue
@@ -1,0 +1,52 @@
+<template>
+    <content-section class="!flex-nowrap">
+
+        <div class="flex flex-col justify-center my-2 mb-5 ml-auto">
+            <search-bar :searchType="false" class="flex" />
+            <div class="flex justify-center my-2 mb-5 ml-auto">
+                <h2 class="text-sm font-light px-4 py-2">검색 결과</h2>
+                <p class="text-gray-600 px-4 py-2">검색 건수 : {{ dataInfo.length || 0 }} 권</p>
+                <!-- <button @click="$router.push('/')" class="bg-blue-500 text-blue px-4 py-2 rounded">홈으로</button> -->
+            </div>
+        </div>
+
+        <div v-if="dataInfo.length" class="books-grid">
+            <div v-for="data in dataInfo" :key="data.isbn" class="book-card">
+                <img :src="data.thumbnail" alt="Book Thumbnail" class="book-thumbnail" />
+                <div class="book-info">
+                    <h3 class="book-title">{{ data.title }}</h3>
+                    <p class="book-contents">{{ data.contents }}</p>
+                    <p class="book-publisher">출판사: {{ data.publisher }}</p>
+                    <p class="book-price">가격: {{ data.price }}원</p>
+                    <p class="book-datetime">출판일: {{ new Date(data.datetime).toLocaleDateString() }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="no-data" v-else>
+            <p>검색된 책이 없습니다.</p>
+        </div>
+    </content-section>
+</template>
+
+<script setup>
+const { books } = storeToRefs(useBooksStore())
+import { storeToRefs } from 'pinia'
+import useBooksStore from "../stores/books"
+import SearchBar from './SearchBar.vue'
+import ContentSection from './ContentSection.vue'
+import { onUnmounted } from 'vue'
+import { ref } from 'vue'
+
+defineProps({
+    dataInfo: {
+        type: Array,
+        default: (() => [])
+    }
+})
+
+onMounted(() => {
+    // console.log(dataInfo)
+})
+</script>
+
+<style></style>

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -1,36 +1,22 @@
 <template>
     <div>
-        <content-section class="!flex-nowrap">
+        <q-tabs v-model="tab" class="text-primary" dense active-color="primary" indicator-color="primary">
+            <q-tab name="books" label="도서" />
+            <q-tab name="youtube" label="유튜브" />
+            <q-tab name="blog" label="블로그" />
+        </q-tabs>
 
-            <div class="flex flex-col justify-center my-2 mb-5 ml-auto">
-                <search-bar class="flex" />
-                <div class="flex justify-center my-2 mb-5 ml-auto">
-                    <h2 class="text-sm font-light px-4 py-2">검색 결과</h2>
-                    <p class="text-gray-600 px-4 py-2">검색된 책 : {{ books.length || 0 }} 권</p>
-                    <!-- <button @click="$router.push('/')" class="bg-blue-500 text-blue px-4 py-2 rounded">홈으로</button> -->
-                </div>
-            </div>
-
-
-            <!-- <p class="text-gray-600 mb-4">검색어: {{ searchData }}</p> -->
-            <!-- <p class="text-gray-600 mb-4">검색된 유튜브 영상의 개수: {{ youtubeVideos.length }}</p> -->
-
-            <div v-if="books.length" class="books-grid">
-                <div v-for="book in books" :key="book.isbn" class="book-card">
-                    <img :src="book.thumbnail" alt="Book Thumbnail" class="book-thumbnail" />
-                    <div class="book-info">
-                        <h3 class="book-title">{{ book.title }}</h3>
-                        <p class="book-contents">{{ book.contents }}</p>
-                        <p class="book-publisher">출판사: {{ book.publisher }}</p>
-                        <p class="book-price">가격: {{ book.price }}원</p>
-                        <p class="book-datetime">출판일: {{ new Date(book.datetime).toLocaleDateString() }}</p>
-                    </div>
-                </div>
-            </div>
-            <div class="no-data" v-else>
-                <p>검색된 책이 없습니다.</p>
-            </div>
-        </content-section>
+        <q-tab-panels v-model="tab" animated>
+            <q-tab-panel name="books">
+                <search-template :dataInfo="dataInfo" class="search-bar-container" />
+            </q-tab-panel>
+            <q-tab-panel name="youtube">
+                <search-template :dataInfo="dataInfo" class="search-bar-container" />
+            </q-tab-panel>
+            <q-tab-panel name="blog">
+                <div>서비스 예정</div>
+            </q-tab-panel>
+        </q-tab-panels>
     </div>
 </template>
 
@@ -38,8 +24,21 @@
 import ContentSection from '~/components/ContentSection.vue';
 import useBooksStore from '~/stores/books';
 import { storeToRefs } from 'pinia'
+import lodash from 'lodash'
 
-const { books } = storeToRefs(useBooksStore())
+onMounted(() => {
+    const booksStore = useBooksStore()
+    dataInfo = (lodash.cloneDeep(booksStore.books))
+})
+
+onUnmounted(() => {
+    const booksStore = useBooksStore()
+    booksStore.searchBook('')
+    console.log('🧹 cleanup')
+})
+
+let dataInfo = ref([])
+const tab = ref('books')
 
 </script>
 

--- a/plugins/quasar.ts
+++ b/plugins/quasar.ts
@@ -1,5 +1,5 @@
 import { defineNuxtPlugin } from '#app';
-import { Quasar, Notify, Dialog, Loading, QBtn } from 'quasar'; // ✅ QBtn 추가
+import { Quasar, Notify, Dialog, Loading, QBtn, QTooltip, QTab, QTabPanel, QTabs, QTabPanels } from 'quasar'; // ✅ QBtn 추가
 
 
 import 'quasar/dist/quasar.css';
@@ -8,6 +8,12 @@ import '@quasar/extras/material-icons/material-icons.css';
 export default defineNuxtPlugin((nuxtApp) => {
   if (process.client) {
     nuxtApp.vueApp.component('q-btn', QBtn); // ✅ q-btn 전역 등록
+    nuxtApp.vueApp.component('q-tooltip', QTooltip); // ✅ q-tooltip 전역 등록
+    nuxtApp.vueApp.component('q-tab', QTab); // ✅ q-tab 전역 등록
+    nuxtApp.vueApp.component('q-tab-panel', QTabPanel); // ✅ q-tab-panel 전역 등록
+    nuxtApp.vueApp.component('q-tabs', QTabs); // ✅ q-tabs 전역 등록
+    nuxtApp.vueApp.component('q-tab-panels', QTabPanels); // ✅ q-tab-panels 전역 등록
+    // Quasar 플러그인 사용 설정
     nuxtApp.vueApp.use(Quasar, {
       plugins: { Notify, Dialog, Loading }, // 사용하려는 Quasar 플러그인 명시
       config: {


### PR DESCRIPTION
# search 페이지
- 블로그와 유튜브 검색 기능 추가를 위한 서치페이지 텝 기능 추가
- 기존에 있던 search.vue 내용을 components의 템플릿으로 만들어서 다른 곳에서도 사용할 수 있게끔 searchTemplate.vue 파일 추가
- ❌ 현재 하위 컴포넌트로 값을 전달 하지 못하고 있어서 수정 필요
- ❌ hydration node mismatch 경고 해결 필요